### PR TITLE
Handle missing employee data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # challengedata
+
+## Data Setup
+
+`load_employee_data` expects at least one CSV file matching the pattern
+`Employee Information *.csv` inside the directory provided to the function.
+If the directory contains no such files, a `FileNotFoundError` is raised
+indicating that the data could not be located.

--- a/employee_data.py
+++ b/employee_data.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+
+
+def load_employee_data(data_dir: str) -> pd.DataFrame:
+    """Load and combine employee information files from a directory.
+
+    The function searches for CSV files matching the pattern
+    ``Employee Information *.csv`` within ``data_dir`` and concatenates them
+    into a single :class:`~pandas.DataFrame`.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory path containing the employee CSV files.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Combined data from all matched CSV files.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no matching files are found in ``data_dir``.
+    """
+
+    data_path = Path(data_dir)
+    frames: List[pd.DataFrame] = [pd.read_csv(csv_file) for csv_file in data_path.glob("Employee Information *.csv")]
+
+    if not frames:
+        raise FileNotFoundError(
+            f"No 'Employee Information *.csv' files found in {data_path}."
+        )
+
+    return pd.concat(frames, ignore_index=True)


### PR DESCRIPTION
## Summary
- add `load_employee_data` helper that reads "Employee Information *.csv" files
- raise `FileNotFoundError` when no employee information files are found
- document CSV file requirement in new README Data Setup section

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc411932483318aa7103412f074c0