### PR TITLE
Default employee data loader to Downloads directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,21 @@ of the data-loading utilities:
 ./scripts/download_data.sh
 ```
 
-`load_employee_data` expects at least one CSV file matching the pattern
-`Employee Information *.csv` inside the directory provided to the function.
-If the directory contains no such files, a `FileNotFoundError` is raised
-indicating that the data could not be located.
+`load_employee_data` searches for files named `Employee Information *.csv`.
+If no directory is provided, it looks in the user's `Downloads` folder:
+
+```python
+from employee_data import load_employee_data
+
+df = load_employee_data()  # uses ~/Downloads
+```
+
+Pass a path to override the default, such as the directory populated by the
+download script:
+
+```python
+df = load_employee_data("data")
+```
+
+If the chosen directory contains no matching files, a `FileNotFoundError` is
+raised indicating that the data could not be located.

--- a/employee_data.py
+++ b/employee_data.py
@@ -4,17 +4,19 @@ from typing import List
 import pandas as pd
 
 
-def load_employee_data(data_dir: str) -> pd.DataFrame:
+def load_employee_data(data_dir: str | None = None) -> pd.DataFrame:
     """Load and combine employee information files from a directory.
 
     The function searches for CSV files matching the pattern
     ``Employee Information *.csv`` within ``data_dir`` and concatenates them
-    into a single :class:`~pandas.DataFrame`.
+    into a single :class:`~pandas.DataFrame`. When ``data_dir`` is omitted, the
+    function looks for these files in the user's Downloads directory.
 
     Parameters
     ----------
     data_dir:
-        Directory path containing the employee CSV files.
+        Directory path containing the employee CSV files. Defaults to the
+        user's Downloads directory.
 
     Returns
     -------
@@ -27,7 +29,7 @@ def load_employee_data(data_dir: str) -> pd.DataFrame:
         If no matching files are found in ``data_dir``.
     """
 
-    data_path = Path(data_dir)
+    data_path = Path(data_dir) if data_dir else Path.home() / "Downloads"
     frames: List[pd.DataFrame] = [pd.read_csv(csv_file) for csv_file in data_path.glob("Employee Information *.csv")]
 
     if not frames:


### PR DESCRIPTION
## Summary
- Allow `load_employee_data` to default to `~/Downloads` when no directory is specified
- Update usage docs to show optional `data_dir` and default search location

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dd97111dc8331ade722d99990a745