### PR TITLE
feat: allow setting download destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 ## Data Setup
 
-Run the download script to populate the `data/` directory before using any
-of the data-loading utilities:
+Run the download script to populate a directory with sample data before using
+any of the data-loading utilities. Pass an optional destination directory (the
+default is `~/Downloads`):
 
 ```bash
-./scripts/download_data.sh
+./scripts/download_data.sh [DEST_DIR]
+```
+
+For example:
+
+```bash
+./scripts/download_data.sh ~/Downloads
 ```
 
 `load_employee_data` expects at least one CSV file matching the pattern

--- a/scripts/download_data.sh
+++ b/scripts/download_data.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# Download sample employee data into the data/ directory.
+# Download sample employee data into a destination directory.
 set -euo pipefail
 
-DATA_DIR="data"
-mkdir -p "$DATA_DIR"
+DEST_DIR="${1:-$HOME/Downloads}"
+mkdir -p "$DEST_DIR"
 
 # Sample dataset; replace URL with the actual dataset location if needed.
 BASE_URL="https://raw.githubusercontent.com/plotly/datasets/master"
 FILE="2014_usa_states.csv"
 
-curl -L "$BASE_URL/$FILE" -o "$DATA_DIR/Employee Information 1.csv"
+curl -L "$BASE_URL/$FILE" -o "$DEST_DIR/Employee Information 1.csv"
 
-echo "Data downloaded to $DATA_DIR/Employee Information 1.csv"
+echo "Data downloaded to $DEST_DIR/Employee Information 1.csv"


### PR DESCRIPTION
## Summary
- make download script accept optional destination dir defaulting to `~/Downloads`
- document new usage example in README

## Testing
- `bash scripts/download_data.sh` *(fails: CONNECT tunnel failed, response 403)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd9726f3483319f32258accc8e421